### PR TITLE
Fix message input newline handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -79,7 +79,7 @@ function MessageInput({ onSend }) {
   };
 
   const handleKey = e => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       send();
     }
@@ -93,7 +93,7 @@ function MessageInput({ onSend }) {
       value,
       placeholder: 'Ask something...',
       onChange: e => setValue(e.target.value),
-      onKeyPress: handleKey
+      onKeyDown: handleKey
     }),
     React.createElement(
       'button',


### PR DESCRIPTION
## Summary
- tweak key handler to allow Shift+Enter for new lines

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_687aa4a490cc8327a11c05d43071ee5d