### PR TITLE
Enhance chat UI with theme switch, timestamps and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ The interface now mirrors the core layout of ChatGPT and includes a few quality 
 * Conversations can be renamed or deleted directly from the sidebar.
 * The current chat can be cleared without removing the conversation itself.
 * Layout tweaks better match ChatGPT's familiar look and feel.
+* Toggle between light and dark themes.
+* Messages include timestamps and a copy button.
+* Conversations can be exported to JSON.

--- a/index.html
+++ b/index.html
@@ -13,6 +13,14 @@
       border: 1px solid rgba(255, 255, 255, 0.2);
       backdrop-filter: blur(12px);
     }
+    body.light {
+      background: #f3f4f6;
+      color: #1f2937;
+    }
+    body.light .glass {
+      background: rgba(255, 255, 255, 0.8);
+      border: 1px solid rgba(0, 0, 0, 0.1);
+    }
   </style>
 </head>
 <body class="bg-gradient-to-br from-gray-900 via-gray-800 to-gray-700 text-gray-200 h-screen">


### PR DESCRIPTION
## Summary
- allow toggling between light and dark themes
- show message timestamps and copy button
- enable exporting a conversation to JSON
- document new features

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_687aa8d893e08327944ca84f7c3cb542